### PR TITLE
Downgrade pybullet version from 3.2.7 to 3.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
    "tqdm>=4.66.2",
    "threadpoolctl>=3.5.0",
    # PyBullet dependencies
-   "pybullet==3.2.7",
+   "pybullet==3.2.5",
    "pybullet-helpers@git+https://github.com/tomsilver/pybullet-helpers.git",
 ]
 


### PR DESCRIPTION
The current dependency pin pybullet==3.2.7 fails to install on macOS Sequoia (15). Version 3.2.7 does not provide a prebuilt wheel for this platform. As a result, pip falls back to compiling the C++ sources, which triggers known build issues with Bullet on macOS/clang (bulletphysics/bullet3#4659). So updating the requirement to 3.2.5.