### PR TITLE
Fix mujoco referencing and simulation divergence issue

### DIFF
--- a/src/prbench/envs/tidybot/arm_controller.py
+++ b/src/prbench/envs/tidybot/arm_controller.py
@@ -36,7 +36,7 @@ class ArmController:
         qpos: Current joint positions (rad).
         qvel: Current joint velocities (rad/s).
         ctrl: Actuator targets for arm joints (rad).
-        qpos_gripper: Current gripper position/state.
+        qpos_gripper: Current gripper position/state (optional).
         ctrl_gripper: Actuator target for gripper (0..gripper_scale).
         ik_solver: Inverse kinematics solver (configured with ``ee_offset``).
         otg: Ruckig trajectory generator instance.
@@ -56,7 +56,7 @@ class ArmController:
         qpos: NDArray[np.float64],
         qvel: NDArray[np.float64],
         ctrl: NDArray[np.float64],
-        qpos_gripper: NDArray[np.float64],
+        qpos_gripper: Optional[NDArray[np.float64]],
         ctrl_gripper: NDArray[np.float64],
         timestep: float,
         ee_offset: float = 0.12,

--- a/src/prbench/envs/tidybot/mujoco_utils.py
+++ b/src/prbench/envs/tidybot/mujoco_utils.py
@@ -286,7 +286,7 @@ class MjModel:
         self._model = mujoco.MjModel.from_xml_string(xml_string)
         self._make_mappings()
 
-    def get_joint_qpos_addr(self, name):
+    def get_joint_qpos_addr(self, name: str) -> int:
         """
         See
         https://github.com/openai/mujoco-py/blob/ab86d331c9a77ae412079c6e58b8771fe63747fc/mujoco_py/generated/wrappers.pxi#L1178

--- a/src/prbench/envs/tidybot/mujoco_utils.py
+++ b/src/prbench/envs/tidybot/mujoco_utils.py
@@ -286,6 +286,54 @@ class MjModel:
         self._model = mujoco.MjModel.from_xml_string(xml_string)
         self._make_mappings()
 
+    def get_joint_qpos_addr(self, name):
+        """
+        See
+        https://github.com/openai/mujoco-py/blob/ab86d331c9a77ae412079c6e58b8771fe63747fc/mujoco_py/generated/wrappers.pxi#L1178
+
+        Returns the qpos address for given joint.
+
+        Args:
+            name (str): name of the joint
+
+        Returns:
+            address (int): returns int address in qpos array
+        """
+        if name not in self._joint_name2id:
+            # Filter out None names for display
+            available_names = [n for n in self.joint_names if n is not None]
+            raise ValueError(
+                f'No "joint" with name {name} exists. '
+                f'Available "joint" names = {available_names}.'
+            )
+        joint_id = self._joint_name2id[name]
+        assert joint_id is not None, "Joint ID should not be None here."
+        return self._model.jnt_qposadr[joint_id]
+
+    def get_joint_qvel_addr(self, name: str) -> int:
+        """
+        See
+        https://github.com/openai/mujoco-py/blob/ab86d331c9a77ae412079c6e58b8771fe63747fc/mujoco_py/generated/wrappers.pxi#L1202
+
+        Returns the qvel address for given joint.
+
+        Args:
+            name (str): name of the joint
+
+        Returns:
+            address (int): returns int address in qvel array
+        """
+        if name not in self._joint_name2id:
+            # Filter out None names for display
+            available_names = [n for n in self.joint_names if n is not None]
+            raise ValueError(
+                f'No "joint" with name {name} exists. '
+                f'Available "joint" names = {available_names}.'
+            )
+        joint_id = self._joint_name2id[name]
+        assert joint_id is not None, "Joint ID should not be None here."
+        return self._model.jnt_dofadr[joint_id]
+
     def _make_mappings(self) -> None:
         """Make some useful internal mappings that mujoco-py supported."""
         self.body_names: tuple[str | None, ...]
@@ -399,9 +447,8 @@ class MjModel:
     ) -> tuple[tuple[str | None, ...], dict[str | None, int], dict[int, str | None]]:
         """Extract MuJoCo object names and create mappings.
 
-        See: https://github.com/openai/mujoco-py/blob/
-             ab86d331c9a77ae412079c6e58b8771fe63747fc/
-             mujoco_py/generated/wrappers.pxi#L1127
+        See:
+        https://github.com/openai/mujoco-py/blob/ab86d331c9a77ae412079c6e58b8771fe63747fc/mujoco_py/generated/wrappers.pxi#L1127
         """
 
         # Objects don't need to be named in the XML, so name might be None

--- a/src/prbench/envs/tidybot/tidybot_robot_env.py
+++ b/src/prbench/envs/tidybot/tidybot_robot_env.py
@@ -140,25 +140,13 @@ class TidyBotRobotEnv(MujocoEnv):
         )
         arm_ctrl_start, arm_ctrl_end = min(arm_ctrl_indices), max(arm_ctrl_indices) + 1
 
-        self.qpos_base = self.sim.data.qpos[
-            base_qpos_start:base_qpos_end
-        ]
-        self.qvel_base = self.sim.data.qvel[
-            base_qvel_start:base_qvel_end
-        ]
-        self.ctrl_base = self.sim.data.ctrl[
-            base_ctrl_start:base_ctrl_end
-        ]
+        self.qpos_base = self.sim.data.qpos[base_qpos_start:base_qpos_end]
+        self.qvel_base = self.sim.data.qvel[base_qvel_start:base_qvel_end]
+        self.ctrl_base = self.sim.data.ctrl[base_ctrl_start:base_ctrl_end]
 
-        self.qpos_arm = self.sim.data.qpos[
-            arm_qpos_start:arm_qpos_end
-        ]
-        self.qvel_arm = self.sim.data.qvel[
-            arm_qvel_start:arm_qvel_end
-        ]
-        self.ctrl_arm = self.sim.data.ctrl[
-            arm_ctrl_start:arm_ctrl_end
-        ]
+        self.qpos_arm = self.sim.data.qpos[arm_qpos_start:arm_qpos_end]
+        self.qvel_arm = self.sim.data.qvel[arm_qvel_start:arm_qvel_end]
+        self.ctrl_arm = self.sim.data.ctrl[arm_ctrl_start:arm_ctrl_end]
 
         # Buffers for gripper
         gripper_ctrl_id = (
@@ -167,9 +155,7 @@ class TidyBotRobotEnv(MujocoEnv):
             ]
         )
         self.qpos_gripper = None
-        self.ctrl_gripper = self.sim.data.ctrl[
-            gripper_ctrl_id : gripper_ctrl_id + 1
-        ]
+        self.ctrl_gripper = self.sim.data.ctrl[gripper_ctrl_id : gripper_ctrl_id + 1]
 
     def reset(
         self, xml_string: str

--- a/src/prbench/envs/tidybot/tidybot_robot_env.py
+++ b/src/prbench/envs/tidybot/tidybot_robot_env.py
@@ -140,23 +140,23 @@ class TidyBotRobotEnv(MujocoEnv):
         )
         arm_ctrl_start, arm_ctrl_end = min(arm_ctrl_indices), max(arm_ctrl_indices) + 1
 
-        self.qpos_base: NDArray[np.float64] = self.sim.data.qpos[
+        self.qpos_base = self.sim.data.qpos[
             base_qpos_start:base_qpos_end
         ]
-        self.qvel_base: NDArray[np.float64] = self.sim.data.qvel[
+        self.qvel_base = self.sim.data.qvel[
             base_qvel_start:base_qvel_end
         ]
-        self.ctrl_base: NDArray[np.float64] = self.sim.data.ctrl[
+        self.ctrl_base = self.sim.data.ctrl[
             base_ctrl_start:base_ctrl_end
         ]
 
-        self.qpos_arm: NDArray[np.float64] = self.sim.data.qpos[
+        self.qpos_arm = self.sim.data.qpos[
             arm_qpos_start:arm_qpos_end
         ]
-        self.qvel_arm: NDArray[np.float64] = self.sim.data.qvel[
+        self.qvel_arm = self.sim.data.qvel[
             arm_qvel_start:arm_qvel_end
         ]
-        self.ctrl_arm: NDArray[np.float64] = self.sim.data.ctrl[
+        self.ctrl_arm = self.sim.data.ctrl[
             arm_ctrl_start:arm_ctrl_end
         ]
 
@@ -166,8 +166,8 @@ class TidyBotRobotEnv(MujocoEnv):
                 "fingers_actuator"
             ]
         )
-        self.qpos_gripper: NDArray[np.float64] | None = None
-        self.ctrl_gripper: NDArray[np.float64] = self.sim.data.ctrl[
+        self.qpos_gripper = None
+        self.ctrl_gripper = self.sim.data.ctrl[
             gripper_ctrl_id : gripper_ctrl_id + 1
         ]
 
@@ -205,6 +205,8 @@ class TidyBotRobotEnv(MujocoEnv):
         assert (
             self.sim is not None
         ), "Simulation must be initialized before randomizing base pose."
+        assert self.qpos_base is not None, "Base qpos must be initialized first"
+        assert self.ctrl_base is not None, "Base ctrl must be initialized first"
 
         # Define limits for x, y, and theta
         x_limit = (-1.0, 1.0)
@@ -429,6 +431,15 @@ class TidyBotRobotEnv(MujocoEnv):
         assert (
             self.sim is not None
         ), "Simulation must be initialized before setting up controllers."
+
+        # Ensure robot references are properly initialized
+        assert self.qpos_base is not None, "Robot references must be set up first"
+        assert self.qvel_base is not None, "Robot references must be set up first"
+        assert self.ctrl_base is not None, "Robot references must be set up first"
+        assert self.qpos_arm is not None, "Robot references must be set up first"
+        assert self.qvel_arm is not None, "Robot references must be set up first"
+        assert self.ctrl_arm is not None, "Robot references must be set up first"
+        assert self.ctrl_gripper is not None, "Robot references must be set up first"
 
         # Initialize controllers
         self.base_controller = BaseController(

--- a/src/prbench/envs/tidybot/tidybot_robot_env.py
+++ b/src/prbench/envs/tidybot/tidybot_robot_env.py
@@ -161,9 +161,11 @@ class TidyBotRobotEnv(MujocoEnv):
         ]
 
         # Buffers for gripper
-        gripper_ctrl_id = self.sim.model._actuator_name2id[
-            "fingers_actuator"
-        ]  # pylint: disable=protected-access
+        gripper_ctrl_id = (
+            self.sim.model._actuator_name2id[  # pylint: disable=protected-access
+                "fingers_actuator"
+            ]
+        )
         self.qpos_gripper: NDArray[np.float64] | None = None
         self.ctrl_gripper: NDArray[np.float64] = self.sim.data.ctrl[
             gripper_ctrl_id : gripper_ctrl_id + 1


### PR DESCRIPTION
This PR adds two major fixes to the TidyBot mujoco env setup:

1. Removes hard-coded referencing to robot's `qpos`/`qvel`/`ctrl` in mujoco sim - otherwise referencing could break if the the order of objects and robot merge into the xml is reversed
2. Fixes option tag import from robot xml - without which simulation diverges