### PR TITLE
Get object poses in TidyBot task class

### DIFF
--- a/src/prbench/envs/tidybot/tidybot3d.py
+++ b/src/prbench/envs/tidybot/tidybot3d.py
@@ -54,6 +54,9 @@ class TidyBot3DEnv(gymnasium.Env[NDArray[np.float32], NDArray[np.float32]]):
             seed=seed, camera_names=camera_names, show_viewer=show_viewer
         )
 
+        # Initialize empty object list
+        self._object_names: list[str] = []
+
         # Set random number generator
         self.np_random = self._tidybot_robot_env.np_random
 
@@ -165,31 +168,8 @@ class TidyBot3DEnv(gymnasium.Env[NDArray[np.float32], NDArray[np.float32]]):
                 # Insert new cubes
                 for i in range(self.num_objects):
                     name = f"cube{i+1}"
-                    body = ET.Element("body", name=name, pos="0 0 0")
-                    ET.SubElement(body, "freejoint")
-                    pos = "0 0 0"
-                    if self.scene_type == "cupboard":
-                        pass  # no position randomization for cupboard scene
-                    elif self.scene_type == "table":
-                        # Randomize position within a reasonable range
-                        # for the table environment
-                        x = round(self.np_random.uniform(0.2, 0.8), 3)
-                        y = round(self.np_random.uniform(-0.15, 0.15), 3)
-                        z = 0.44
-                        pos = f"{x} {y} {z}"
-                    else:
-                        # Randomize position within a reasonable range
-                        # for the ground environment
-                        x = round(self.np_random.uniform(0.4, 0.8), 3)
-                        y = round(self.np_random.uniform(-0.3, 0.3), 3)
-                        z = 0.02
-                        pos = f"{x} {y} {z}"
-                    # Randomize orientation around Z-axis (yaw)
-                    theta = self.np_random.uniform(-math.pi, math.pi)
-                    quat_array = np.array(
-                        [math.cos(theta / 2), 0, 0, math.sin(theta / 2)]
-                    )
-                    quat = " ".join(map(str, quat_array))
+                    body = ET.Element("body", name=f"{name}_body")
+                    ET.SubElement(body, "freejoint", name=f"{name}_joint")
                     ET.SubElement(
                         body,
                         "geom",
@@ -197,10 +177,10 @@ class TidyBot3DEnv(gymnasium.Env[NDArray[np.float32], NDArray[np.float32]]):
                         size="0.02 0.02 0.02",
                         rgba=".5 .7 .5 1",
                         mass="0.1",
-                        pos=pos,
-                        quat=quat,
+                        name=f"{name}_geom",
                     )
                     worldbody.append(body)
+                    self._object_names.append(name)
 
                 # Get XML string from tree
                 xml_string = ET.tostring(root, encoding="unicode")
@@ -212,6 +192,56 @@ class TidyBot3DEnv(gymnasium.Env[NDArray[np.float32], NDArray[np.float32]]):
                 xml_string = f.read()
 
         return xml_string
+
+    def _set_object_pos_quat(self, name, pos, quat) -> None:
+        """Set object position and orientation in the environment."""
+
+        joint_id = self._tidybot_robot_env.sim.model.get_joint_qpos_addr(
+            f"{name}_joint"
+        )
+        self._tidybot_robot_env.sim.data.qpos[joint_id : joint_id + 7] = np.array(
+            [float(x) for x in pos] + [float(q) for q in quat]
+        )
+
+    def get_object_pos_quat(self, name) -> tuple[float, float]:
+        """Set object position and orientation in the environment."""
+
+        joint_id = self._tidybot_robot_env.sim.model.get_joint_qpos_addr(
+            f"{name}_joint"
+        )
+        pos = self._tidybot_robot_env.sim.data.qpos[joint_id : joint_id + 3]
+        quat = self._tidybot_robot_env.sim.data.qpos[joint_id + 3 : joint_id + 7]
+        return pos, quat
+
+    def _initialize_object_poses(self) -> None:
+        """Initialize object poses in the environment."""
+
+        for name in self._object_names:
+            pos = [0, 0, 0]
+            if self.scene_type == "cupboard":
+                pass  # no position randomization for cupboard scene
+            elif self.scene_type == "table":
+                # Randomize position within a reasonable range
+                # for the table environment
+                x = round(self.np_random.uniform(0.2, 0.8), 3)
+                y = round(self.np_random.uniform(-0.15, 0.15), 3)
+                z = 0.44
+                pos = [x, y, z]
+            else:
+                # Randomize position within a reasonable range
+                # for the ground environment
+                x = round(self.np_random.uniform(0.4, 0.8), 3)
+                y = round(self.np_random.uniform(-0.3, 0.3), 3)
+                z = 0.02
+                pos = [x, y, z]
+            # Randomize orientation around Z-axis (yaw)
+            theta = self.np_random.uniform(-math.pi, math.pi)
+            quat = np.array([math.cos(theta / 2), 0, 0, math.sin(theta / 2)])
+
+            # Set object pose in the environment
+            self._set_object_pos_quat(name, pos, quat)
+
+        self._tidybot_robot_env.sim.forward()
 
     def reset(
         self, *args: Any, **kwargs: Any
@@ -227,7 +257,14 @@ class TidyBot3DEnv(gymnasium.Env[NDArray[np.float32], NDArray[np.float32]]):
         xml_string = self._create_scene_xml()
 
         # Reset the underlying TidyBot robot environment
-        obs, _, _, _ = self._tidybot_robot_env.reset(xml_string)
+        self._tidybot_robot_env.reset(xml_string)
+
+        # initialize object poses
+        self._object_names = []
+        self._initialize_object_poses()
+
+        # Get observation and vectorize
+        obs = self._tidybot_robot_env.get_obs()
 
         vec_obs = self._vectorize_observation(obs)
         return vec_obs, {}

--- a/tests/envs/tidybot/test_tidybot3d_basic.py
+++ b/tests/envs/tidybot/test_tidybot3d_basic.py
@@ -59,3 +59,36 @@ def test_tidybot3d_step_returns_valid_outputs():
     assert isinstance(truncated, bool), "Truncated is not a bool"
     assert isinstance(info, dict), "Info is not a dict"
     env.close()
+
+
+def test_tidybot3d_get_object_pos_quat():
+    """Test that get_object_pos_quat() returns valid position and orientation."""
+    env = TidyBot3DEnv(num_objects=3, render_images=False)
+    env.reset()
+    for name in env._object_names:  # pylint: disable=protected-access
+        pos, quat = env.get_object_pos_quat(name)
+        assert len(pos) == 3, "Position should have 3 elements"
+        assert len(quat) == 4, "Quaternion should have 4 elements"
+    env.close()
+
+
+def test_tidybot3d_set_get_object_pos_quat_consistency():
+    """Test that setting and then getting an object's position and orientation is
+    consistent."""
+    env = TidyBot3DEnv(num_objects=3, render_images=False)
+    env.reset()
+    for name in env._object_names:  # pylint: disable=protected-access
+        original_pos, original_quat = env.get_object_pos_quat(name)
+        new_pos = [p + 0.1 for p in original_pos]
+        new_quat = original_quat  # Keep orientation the same for simplicity
+        env._set_object_pos_quat(  # pylint: disable=protected-access
+            name, new_pos, new_quat
+        )
+        updated_pos, updated_quat = env.get_object_pos_quat(name)
+        assert all(
+            abs(o - u) < 1e-5 for o, u in zip(new_pos, updated_pos)
+        ), "Position not set correctly"
+        assert all(
+            abs(o - u) < 1e-5 for o, u in zip(new_quat, updated_quat)
+        ), "Orientation not set correctly"
+    env.close()


### PR DESCRIPTION
This PR adds support for getting object poses in TidyBot task class. Changes were made to set object pose as joint value of the body's freejoint, instead of geom's pose in the object body. This also means that object poses are now set after mujoco sim initialization.